### PR TITLE
Update Action.php

### DIFF
--- a/Action.php
+++ b/Action.php
@@ -27,8 +27,8 @@ class Action extends \yii\base\Action
             Yii::error($e, 'service.error');
             $this->exception = new Exception($e->getMessage(), Exception::INTERNAL_ERROR);
         }
-        echo $this->toJson();
         Yii::endProfile('service.request');
+        return $this->toJson();
     }
 
     /**


### PR DESCRIPTION
При вызове у yii2/web/Response метода sendHeaders, функция headers_sent() возвращает true, так как у тебя в методе run твоего экшена делается echo. Как следствие происходит сразу выход из функции sendHeaders и дело не доходит до установки cookies. Это подтвердилось вызовом функции  headers_sent() с двумя параметрами. Она указала на nizsheanez/yii2-json-rpc/nizsheanez/jsonRpc/Action на 30 строку(echo $this->toJson();).